### PR TITLE
feat: add OrderById method on GroupService/MaimuService

### DIFF
--- a/src/main/java/com/example/chosim/chosim/repository/GroupRepository.java
+++ b/src/main/java/com/example/chosim/chosim/repository/GroupRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
-    List<Group> findByUserEntity_Id(Long id);
+    List<Group> findByUserEntity_IdOrderByIdAsc(Long id);
 }

--- a/src/main/java/com/example/chosim/chosim/repository/maimu/MaimuRepository.java
+++ b/src/main/java/com/example/chosim/chosim/repository/maimu/MaimuRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MaimuRepository extends JpaRepository<Maimu, Long>, MaimuRepositoryCustom{
-    List<Maimu> findByGroup_Id(Long id);
+    List<Maimu> findByGroup_IdOrderByIdAsc(Long id);
 }

--- a/src/main/java/com/example/chosim/chosim/service/GroupService.java
+++ b/src/main/java/com/example/chosim/chosim/service/GroupService.java
@@ -62,7 +62,7 @@ public class GroupService {
         UserEntity userEntity = userRepository.findByUsername(username)
                 .orElseThrow(UserEntityNotFound::new);
 
-        return groupRepository.findByUserEntity_Id(userEntity.getId()).stream()
+        return groupRepository.findByUserEntity_IdOrderByIdAsc(userEntity.getId()).stream()
                 .map(GroupResponse::new)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/chosim/chosim/service/MaimuService.java
+++ b/src/main/java/com/example/chosim/chosim/service/MaimuService.java
@@ -55,7 +55,7 @@ public class MaimuService {
     }
 
     public List<MaimuResponse> getList(Long id){
-        return maimuRepository.findByGroup_Id(id).stream()
+        return maimuRepository.findByGroup_IdOrderByIdAsc(id).stream()
                 .map(MaimuResponse::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
그룹/마이무 list 반환 시 이름 순으로 정렬되는 문제 해결
OrderById 메소드 추가하여 Id 즉 생성된 순서로 정렬